### PR TITLE
Waypoint sampler format

### DIFF
--- a/descartes_light/core/include/descartes_light/core/waypoint_sampler.h
+++ b/descartes_light/core/include/descartes_light/core/waypoint_sampler.h
@@ -59,6 +59,14 @@ public:
    * sampling step
    */
   virtual typename std::vector<StateSample<FloatType>> sample() const = 0;
+
+  virtual std::ostream& format(std::ostream& out) const
+  {
+    out << "WaypointSampler format() not defined";
+    return out;
+  }
+
+  friend std::ostream& operator<<(std::ostream& os, const WaypointSampler<FloatType>& wps) { return wps.format(os); }
 };
 
 using WaypointSamplerF = WaypointSampler<float>;

--- a/descartes_light/core/include/descartes_light/samplers/fixed_joint_waypoint_sampler.h
+++ b/descartes_light/core/include/descartes_light/samplers/fixed_joint_waypoint_sampler.h
@@ -31,6 +31,8 @@ public:
 
   std::vector<StateSample<FloatType>> sample() const override;
 
+  virtual std::ostream& format(std::ostream& out) const override;
+
 private:
   typename State<FloatType>::ConstPtr fixed_joint_position_;
 };

--- a/descartes_light/core/include/descartes_light/samplers/impl/fixed_joint_waypoint_sampler.hpp
+++ b/descartes_light/core/include/descartes_light/samplers/impl/fixed_joint_waypoint_sampler.hpp
@@ -35,6 +35,13 @@ std::vector<StateSample<FloatType>> FixedJointWaypointSampler<FloatType>::sample
   return { StateSample<FloatType>{ fixed_joint_position_, static_cast<FloatType>(0.0) } };
 }
 
+template <typename FloatType>
+std::ostream& FixedJointWaypointSampler<FloatType>::format(std::ostream& out) const
+{
+  out << fixed_joint_position_->values;
+  return out;
+}
+
 }  // namespace descartes_light
 
 #endif  // DESCARTES_SAMPLERS_SAMPLERS_IMPL_FIXED_JOINT_WAYPOINT_SAMPLER_HPP


### PR DESCRIPTION
- Easier output of waypoint samplers.
- Use cout to print failed graph.  console_bridge has a maximum buffer size and will cut off messages.  
  - spdlog would be better...